### PR TITLE
add method to 'dump' messages without formatting.

### DIFF
--- a/lib/omni_logger.rb
+++ b/lib/omni_logger.rb
@@ -51,6 +51,10 @@ class OmniLogger
     @loggers.each { |logger| logger.add(level, args) }
   end
 
+  def <<(msg)
+    @loggers.map { |logger| logger << msg }
+  end
+
   Logger::Severity.constants.each do |level|
     define_method(level.downcase) do |*args|
       @loggers.each { |logger| logger.send(level.downcase, args) }


### PR DESCRIPTION
This adds support for [`Logger#<<`](http://ruby-doc.org/stdlib-2.2.3/libdoc/logger/rdoc/Logger.html#method-i-3C-3C) which is needed if you want to use
OmniLogger with things like `Rack::CommonLogger`.
