### PR TITLE
Avoid array brackets

### DIFF
--- a/lib/omni_logger.rb
+++ b/lib/omni_logger.rb
@@ -57,7 +57,7 @@ class OmniLogger
 
   Logger::Severity.constants.each do |level|
     define_method(level.downcase) do |*args|
-      @loggers.each { |logger| logger.send(level.downcase, args) }
+      @loggers.each { |logger| logger.send(level.downcase, *args) }
     end
 
     define_method("#{ level.downcase }?".to_sym) do


### PR DESCRIPTION
without this, one message will be passed as an Array with one element, leading to log messages appearing with brackets like this: 

["Foobar debugging from local machine at 2017-07-31 16:44:06 +0200"]